### PR TITLE
Remove v-once from the GlMap element

### DIFF
--- a/src/components/GlMap.vue
+++ b/src/components/GlMap.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-once :id="container" ref="container">
+  <div :id="container" ref="container">
     <slot/>
   </div>
 </template>


### PR DESCRIPTION
Removing `v-once` from inside the GlMap element so it can be controlled by the user.  `v-once` can now be placed on the element when being used:

```html
<mgl-map
  v-once
  :accessToken=“accessToken”
  :mapStyle.sync="mapStyle"
></mgl-map>
```

This allows markers to be created and removed using `v-if`.