### PR TITLE
Fix Vue warning about Marker name

### DIFF
--- a/src/components/UI/Marker.vue
+++ b/src/components/UI/Marker.vue
@@ -9,7 +9,7 @@
   import baseMixin from '../../lib/mixin'
 
   export default {
-    name: 'Marker',
+    name: 'MapboxMarker',
     mixins: [baseMixin],
     props: {
       // mapbox marker options


### PR DESCRIPTION
Vue throws an error due to the Marker name/id being a reserved word.  This changes the name to get rid of the error.

![screen shot 2018-05-26 at 6 35 14 am](https://user-images.githubusercontent.com/128857/40576225-63c61602-60af-11e8-8aa9-d866fdfa1ca3.jpg)
