### PR TITLE
Marker popup slot & color prop

### DIFF
--- a/docs/markers.md
+++ b/docs/markers.md
@@ -1,2 +1,96 @@
 # Markers
-_Coming soon_
+
+The Marker component is a wrapper around the [Mapbox GL Marker API](https://www.mapbox.com/mapbox-gl-js/api/#marker).
+
+```vue
+<template>
+  <mgl-map
+    :accessToken="mapboxAccessToken"
+    :mapStyle.sync="mapStyle"
+    :center="coordinates"
+  >
+    <mgl-marker :coordinates="coordinates" color="blue"></mgl-marker>
+  </mgl-map>
+</template>
+
+<script>
+export default {
+  data: () => ({
+    mapStyle: 'mapbox://styles/mapbox/basic-v10',
+    coordinates: [ -111.549668, 39.014 ]
+  })
+}
+</script>
+```
+
+## Props
+
+- `color {String}` Set the color of the default marker (not applicable when using the `marker` slot)
+- `coordinates {Array}` The GeoJSON coordinates for marker placement on the map
+- `offset {Object, Array}` Display the marker at an offset distance from the coordinates
+
+## Slots
+
+The Marker component has two slots: the `marker` slot and the `popup` slot.
+
+### The `marker` slot
+
+The `marker` slot allows you to customize the look of the marker.  Here is an example of using the [Vuetify `v-icon` component](https://vuetifyjs.com/en/components/icons) instead of the default marker icon:
+
+```vue
+<template>
+  <mgl-map
+    :accessToken="mapboxAccessToken"
+    :mapStyle.sync="mapStyle"
+    :center="coordinates"
+  >
+    <mgl-marker :coordinates="coordinates">
+
+      <v-icon slot="marker">mdi-map-marker</v-icon>
+
+    </mgl-marker>
+  </mgl-map>
+</template>
+
+<script>
+export default {
+  data: () => ({
+    mapStyle: 'mapbox://styles/mapbox/basic-v10',
+    coordinates: [ -111.549668, 39.014 ]
+  })
+}
+</script>
+```
+
+### The `popup` slot
+
+The `popup` slot allows you to specify content to display in a Mapbox popup when the marker is clicked.
+
+```vue
+<template>
+  <mgl-map
+    :accessToken="mapboxAccessToken"
+    :mapStyle.sync="mapStyle"
+    :center="coordinates"
+  >
+    <mgl-marker :coordinates="coordinates">
+
+      <div slot="popup">
+        <h1>This is a heading</h1>
+        <p>This is a p</p>
+        <button @click.prevent="performSomeAction">Do Something</button>
+      </div>
+
+    </mgl-marker>
+  </mgl-map>
+</template>
+
+<script>
+export default {
+  data: () => ({
+    mapStyle: 'mapbox://styles/mapbox/basic-v10',
+    coordinates: [ -111.549668, 39.014 ]
+  })
+}
+</script>
+```

--- a/src/components/UI/Marker.vue
+++ b/src/components/UI/Marker.vue
@@ -1,7 +1,7 @@
 <template>
   <div style="display: none">
-    <slot name="marker"/>
-    <slot/>
+    <slot name="marker"/><slot/>
+    <slot name="popup"/><slot/>
   </div>
 </template>
 
@@ -50,10 +50,22 @@
     methods: {
       $_deferredMount(payload) {
         if (!this.marker) {
+          const markerOptions = {
+            ...this._props
+          }
+
           if (this.$slots.marker) {
-            this.marker = new this.mapbox.Marker(this.$slots.marker[0].elm, { ...this._props })
-          } else {
-            this.marker = new this.mapbox.Marker()
+            markerOptions.element = this.$slots.marker[0].elm
+          }
+
+          this.marker = new this.mapbox.Marker(markerOptions)
+
+          if (this.$slots.popup) {
+            const popup = this.popup = new this.mapbox.Popup()
+              .setLngLat(this.coordinates)
+              .setDOMContent(this.$slots.popup[0].elm)
+
+            this.marker.setPopup(popup)
           }
         }
 


### PR DESCRIPTION
This modifies the Marker component so that the props are always consistently passed when instantiating the `mapbox.Marker` class.

It also adds a `color` prop, which allows you to customize the default marker’s color.

Another slot has been added to the component.  The `popup` slot provides a quick way to create a popup that displays when the marker is clicked.  It allows passing markup, and the Vue events & template syntax all work wonderfully.

To wrap it up, I’ve added some documentation on Markers in `markers.md`:

# Markers

The Marker component is a wrapper around the [Mapbox GL Marker API](https://www.mapbox.com/mapbox-gl-js/api/#marker).

```vue
<template>
  <mgl-map
    :accessToken="mapboxAccessToken"
    :mapStyle.sync="mapStyle"
    :center="coordinates"
  >
    <mgl-marker :coordinates="coordinates" color="blue"></mgl-marker>
  </mgl-map>
</template>

<script>
export default {
  data: () => ({
    mapStyle: 'mapbox://styles/mapbox/basic-v10',
    coordinates: [ -111.549668, 39.014 ]
  })
}
</script>
```

## Props

- `color {String}` Set the color of the default marker (not applicable when using the `marker` slot)
- `coordinates {Array}` The GeoJSON coordinates for marker placement on the map
- `offset {Object, Array}` Display the marker at an offset distance from the coordinates

## Slots

The Marker component has two slots: the `marker` slot and the `popup` slot.

### The `marker` slot

The `marker` slot allows you to customize the look of the marker.  Here is an example of using the [Vuetify `v-icon` component](https://vuetifyjs.com/en/components/icons) instead of the default marker icon:

```vue
<template>
  <mgl-map
    :accessToken="mapboxAccessToken"
    :mapStyle.sync="mapStyle"
    :center="coordinates"
  >
    <mgl-marker :coordinates="coordinates">

      <v-icon slot="marker">mdi-map-marker</v-icon>

    </mgl-marker>
  </mgl-map>
</template>

<script>
export default {
  data: () => ({
    mapStyle: 'mapbox://styles/mapbox/basic-v10',
    coordinates: [ -111.549668, 39.014 ]
  })
}
</script>
```

### The `popup` slot

The `popup` slot allows you to specify content to display in a Mapbox popup when the marker is clicked.

```vue
<template>
  <mgl-map
    :accessToken="mapboxAccessToken"
    :mapStyle.sync="mapStyle"
    :center="coordinates"
  >
    <mgl-marker :coordinates="coordinates">

      <div slot="popup">
        <h1>This is a heading</h1>
        <p>This is a p</p>
        <button @click.prevent="performSomeAction">Do Something</button>
      </div>

    </mgl-marker>
  </mgl-map>
</template>

<script>
export default {
  data: () => ({
    mapStyle: 'mapbox://styles/mapbox/basic-v10',
    coordinates: [ -111.549668, 39.014 ]
  })
}
</script>
```
