### PR TITLE
Added listenUserEvents prop to layerMixin

### DIFF
--- a/src/components/layer/layerMixin.js
+++ b/src/components/layer/layerMixin.js
@@ -38,6 +38,10 @@ const componentProps = {
   replace: {
     type: Boolean,
     default: false
+  },
+  listenUserEvents: {
+    type: Boolean,
+    default: false
   }
 }
 


### PR DESCRIPTION
Event binding is currently completely inaccessible in layer components because the `listenUserEvents` property does not exist in any of the layer component.