### PR TITLE
Added VectorLayer type prop and changed layerMixin before prop to String

### DIFF
--- a/docs_source/api/Layers/vectorlayer.md
+++ b/docs_source/api/Layers/vectorlayer.md
@@ -49,6 +49,13 @@
 - **Description:** An array containing the longitude and latitude of the southwest and northeast corners of the source's bounding box in the following order: [sw.lng, sw.lat, ne.lng, ne.lat].
 - **See:** `bounds` in [Mapbox Source Style Spec](https://www.mapbox.com/mapbox-gl-js/style-spec/#sources-vector-bounds)
 
+### `type`
+
+- **Type:** `String`
+- **Non-Synced**
+- **Description:** Rendering type of this layer.
+- **See:** `type` in [Mapbox Source Style Spec](https://www.mapbox.com/mapbox-gl-js/style-spec/#layers-type)
+
 ### `scheme`
 
 - **Type:** `String`

--- a/src/components/layer/VectorLayer.js
+++ b/src/components/layer/VectorLayer.js
@@ -25,6 +25,10 @@ export default {
       type: String,
       required: true
     },
+    type: {
+      type: String,
+      required: true
+    },
     bounds: {
       type: Array,
       default: () => [-180, -85.051129, 180, 85.051129]
@@ -77,10 +81,10 @@ export default {
       if (payload.mapId !== this.mapId) return;
       this.map = payload.map;
       let source = {
-        type: "vector",
-        url: this.url
+        type: "vector"
       };
 
+      if (this.url) source.url = this.url;
       if (this.tiles) source.tiles = this.tiles;
       if (this.tilesMinZoom) source.minzoom = this.tilesMinZoom;
       if (this.tilesMaxZoom) source.maxzoom = this.tilesMinZoom;

--- a/src/components/layer/VectorLayer.js
+++ b/src/components/layer/VectorLayer.js
@@ -27,7 +27,7 @@ export default {
     },
     type: {
       type: String,
-      required: true
+      default: "fill"
     },
     bounds: {
       type: Array,
@@ -133,7 +133,7 @@ export default {
       if (this.refLayer) {
         layer.ref = this.refLayer;
       } else {
-        layer.type = this.type ? this.type : "fill";
+        layer.type = this.type;
         layer.source = this.sourceId;
         if (this.minzoom) layer.minzoom = this.minzoom;
         if (this.maxzoom) layer.maxzoom = this.maxzoom;

--- a/src/components/layer/layerMixin.js
+++ b/src/components/layer/layerMixin.js
@@ -19,7 +19,7 @@ const mapboxLayerStyleProps = {
   maxZoom: Number,
   paint: Object,
   layout: Object,
-  before: Object,
+  before: String,
   filter: undefined
 };
 


### PR DESCRIPTION
I noticed that prop `type` on VectorLayer is missing and type `fill` was set every time (even if was defined as `outline`), and another problem was that mapboxgl is expecting a string on the before param of addLayer method and was typed as object on layerMixin props