### PR TITLE
Add bounds and fitBoundsOptions from Mapbox GL

### DIFF
--- a/docs_source/api/README.md
+++ b/docs_source/api/README.md
@@ -280,6 +280,20 @@
 - **Description:** If specified, defines a CSS font-family for locally overriding generation of glyphs in the 'CJK Unified Ideographs' and 'Hangul Syllables' ranges. In these ranges, font settings from the map's style will be ignored, except for font-weight keywords (light/regular/medium/bold). The purpose of this option is to avoid bandwidth-intensive glyph server requests.
 - **See:** `options.localIdeographFontFamily` in [Map](https://docs.mapbox.com/mapbox-gl-js/api/#map)
 
+### `bounds`
+
+- **Type:** `Array`, `LngLatBoundsLike object`
+- **Default:** `undefined`
+- **Description:** The initial bounds of the map. If set, it overrides `center` and `zoom` construction options
+- **See:** `options.bounds` in [Map](https://docs.mapbox.com/mapbox-gl-js/api/#map)
+
+### `fitBoundsOptions`
+
+- **Type:** `fitBounds object`
+- **Default:** `undefined`
+- **Description:** A `fitBounds` object to use only when fitting the initial `bounds` provided above
+- **See:** `options.fitBoundsOptions` in [Map](https://docs.mapbox.com/mapbox-gl-js/api/#map)
+
 ## Actions
 
 Asynchronous actions exposed via `GlMap.actions`

--- a/src/components/map/GlMap.vue
+++ b/src/components/map/GlMap.vue
@@ -55,10 +55,6 @@ export default {
     version() {
       return this.map ? this.map.version : null;
     },
-    // TODO: make 'bounds' synced prop
-    bounds() {
-      return this.map ? this.map.getBounds() : null;
-    },
     isStyleLoaded() {
       return this.map ? this.map.isStyleLoaded() : false;
     },

--- a/src/components/map/options.js
+++ b/src/components/map/options.js
@@ -131,8 +131,12 @@ export default {
     type: Number,
     default: 0
   },
-  initialBounds: {
+  bounds: {
     type: [Object, Array],
+    default: undefined
+  },
+  fitBoundsOptions: {
+    type: Object,
     default: undefined
   },
   renderWorldCopies: {


### PR DESCRIPTION
Hello,

I've noticed that the `initialBounds` option in Mapbox GL has been renamed and is now only `bounds`. I've made a PR to take this into account and to add the option `fitBoundsOptions` that is linked with it.

To be noted: the `bounds()` computed property cannot be named like this anymore. I haven't found where this property was used, was it ok to remove it or should we rename it?

Thanks.