### PR TITLE
Make bounds prop synced

### DIFF
--- a/docs_source/api/README.md
+++ b/docs_source/api/README.md
@@ -284,7 +284,8 @@
 
 - **Type:** `Array`, `LngLatBoundsLike object`
 - **Default:** `undefined`
-- **Description:** The initial bounds of the map. If set, it overrides `center` and `zoom` construction options
+- **Synced**
+- **Description:** The bounds of the map. If set, it overrides `center` and `zoom` construction options
 - **See:** `options.bounds` in [Map](https://docs.mapbox.com/mapbox-gl-js/api/#map)
 
 ### `fitBoundsOptions`

--- a/src/components/map/mixins/withPrivateMethods.js
+++ b/src/components/map/mixins/withPrivateMethods.js
@@ -29,9 +29,12 @@ export default {
           events: ["pitch"],
           prop: "pitch",
           getter: this.map.getPitch.bind(this.map)
+        },
+        {
+          events: ["moveend", "zoomend", "rotate", "pitch"],
+          prop: "bounds",
+          getter: this.map.getBounds.bind(this.map)
         }
-        // TODO: make 'bounds' synced prop
-        // { events: ['moveend', 'zoomend', 'rotate', 'pitch'], prop: 'bounds', getter: this.map.getBounds.bind(this.map) }
       ];
       syncedProps.forEach(({ events, prop, getter }) => {
         events.forEach(event => {


### PR DESCRIPTION
With this change, the bounds prop can be used to set the initial bounds for when the map loads (as before), but it also gets updated automatically afterwards as the user moves/zooms in the map.