### PR TITLE
Fix warning about incorrect peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "map-promisified": "latest"
   },
   "peerDependencies": {
-    "mapbox-gl": "^0.53.0",
+    "mapbox-gl": ">=0.53.0",
     "vue": "^2.6.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Since `mapbox-gl` already has version 1.5.x, there is a warning on every package install, even though the newer versions are supported. So I fixed the `package.json` to allow newer versions of `mapbox-gl`.

I'm open for discussion if this should be ">=0.53.0" or rather "<2.0.0" or anything else, but this "fix" would be nice!