### PR TITLE
Fix css for mapbox-gl

### DIFF
--- a/src/components/map/GlMap.vue
+++ b/src/components/map/GlMap.vue
@@ -124,4 +124,8 @@ export default {
   top: 0;
   width: 100%;
 }
+
+.mapboxgl-canvas-container {
+    position: absolute;
+}
 </style>


### PR DESCRIPTION
It seems that the mapbox css is messing up a bit in this context, so that the canvas including the map is only half of the container. With this tiny fix, it should work again.

I read your comment at the README, that you don't want the `dist` files included, but I can add those if wanted nevertheless.