### PR TITLE
fixes documentation for Popup events open and close

### DIFF
--- a/docs_source/api/popup.md
+++ b/docs_source/api/popup.md
@@ -64,15 +64,15 @@
 
 ### `@removed`
 
-- **Description:** Fires when popup removed the map.
+- **Description:** Fires when popup removed from the map.
 - **Payload** `{ popup: Popup }` Object with MapboxGL `Popup` object
 
 ### `@open`
 
-- **Description:** Fires when marker added on the map.
+- **Description:** Fires when popup is opened manually or programatically.
 - **Payload** `{ popup: Popup }` Object with MapboxGL `Popup` object
 
 ### `@close`
 
-- **Description:** Fires when marker added on the map.
+- **Description:** Fires when popup is closed manually or programatically.
 - **Payload** `{ popup: Popup }` Object with MapboxGL `Popup` object


### PR DESCRIPTION
According to the Mapbox API Reference the `open` and `close` events are indicating the state of the Popup and are not fired when markers are added or removed from the map.

Source: [Mapbox API Reference for open and close](https://docs.mapbox.com/mapbox-gl-js/api/#popup.event:open)