### PR TITLE
Update GlMap.vue

### DIFF
--- a/src/components/map/GlMap.vue
+++ b/src/components/map/GlMap.vue
@@ -86,7 +86,7 @@ export default {
   mounted() {
     this.$_loadMap().then(map => {
       this.map = map;
-      if (this.RTLTextPluginUrl !== undefined) {
+      if (this.RTLTextPluginUrl !== undefined && this.mapbox.getRTLTextPluginStatus() !== 'loaded') {
         this.mapbox.setRTLTextPlugin(
           this.RTLTextPluginUrl,
           this.$_RTLTextPluginError


### PR DESCRIPTION
Fix proposal for the following error:

**Uncaught (in promise) Error: setRTLTextPlugin cannot be called multiple times.
    at Object.t.setRTLTextPlugin (mapbox-gl.js?e192:31)
    at eval (GlMap.vue?14e2:95)**

Steps to reproduce:
1 - create vue project with vue-router option enabled
2 - define 2 routes mapping them to 2 different components
3 - in one component add mgl-map component and supply the RTLTextPluginUrl to the map
4 - navigate away to the other route and return to route you should get the above error