### PR TITLE
Use `sourceLayer` for `{get,set}FeatureState()`

### DIFF
--- a/src/components/layer/VectorLayer.js
+++ b/src/components/layer/VectorLayer.js
@@ -89,7 +89,7 @@ export default {
         const params = {
           id: featureId,
           source: this.sourceId,
-          "source-layer": this.layer["source-layer"]
+          sourceLayer: this.layer["source-layer"]
         };
         return this.map.setFeatureState(params, state);
       }
@@ -100,7 +100,7 @@ export default {
         const params = {
           id: featureId,
           source: this.source,
-          "source-layer": this.layer["source-layer"]
+          sourceLayer: this.layer["source-layer"]
         };
         return this.map.getFeatureState(params);
       }


### PR DESCRIPTION
As stated in Mapbox-GL documentation https://docs.mapbox.com/mapbox-gl-js/api/map/#map#setfeaturestate.

I get an `Error: The sourceLayer parameter must be provided for vector source types.` otherwise.

<img width="716" alt="image" src="https://user-images.githubusercontent.com/138627/95899774-4d1b8400-0d91-11eb-8f4d-816dbb1caef7.png">

This is the example from the very same documentation linked above:

```js
// When the mouse moves over the `my-layer` layer, update
// the feature state for the feature under the mouse
map.on('mousemove', 'my-layer', function(e) {
  if (e.features.length > 0) {
    map.setFeatureState({
      source: 'my-source',
      sourceLayer: 'my-source-layer',
      id: e.features[0].id,
    }, {
      hover: true
    });
  }
});
```

refs entrepreneur-interet-general/CartoBio-Presentation#70