### PR TITLE
Allow use of mapbox-gl v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "map-promisified": "latest"
   },
   "peerDependencies": {
-    "mapbox-gl": "^1.12.0",
+    "mapbox-gl": ">=1.12.0",
     "vue": "^2.6.7"
   },
   "devDependencies": {


### PR DESCRIPTION
According to [Mapbox](https://docs.mapbox.com/mapbox-gl-js/api/#migrating-to-v2):
>Mapbox GL JS v2 is backwards-compatible

Also:
>Web maps using Mapbox GL JS v1.0.0 and higher **are billed by Map Loads for Web**

which is good, given that up to 50,000 monthly Map Loads are [free](https://www.mapbox.com/pricing/).
