### PR TITLE
(REPO NO LONGER MAINTAINED: GO TO geospoc/v-mapbox for a active repo) Docs: Fix Duplicate Component Code + typo in controls.md. 

### DIFF
--- a/docs/guide/controls.md
+++ b/docs/guide/controls.md
@@ -19,8 +19,6 @@ _All controls_:
       <MglAttributionControl />
       <MglNavigationControl position="top-right" />
       <MglGeolocateControl position="top-right" />
-      <MglNavigationControl position="top-right" />
-      <MglGeolocateControl position="top-right" />
       <MglScaleControl />
     </MglMap>
   </div>

--- a/docs/guide/controls.md
+++ b/docs/guide/controls.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Controls is UI elemetns for controlling view of the map, such as scale or bearing.
+Controls is UI elements for controlling view of the map, such as scale or bearing.
 You can check them out in Mapbox GL JS [documentation](https://docs.mapbox.com/mapbox-gl-js/api/#user%20interface)
 In Vue-mapbox they exposed as Vue components, so you can control they properties and behavior dynamically by changing props.
 


### PR DESCRIPTION
The code block using the controls in `controls.md` had the same `MglNavigationControl` and `MglGeolocateControl` declared twice. There was also a small typo on the word element.