### PR TITLE
Update watcher for `setLight` to fix typo.

### DIFF
--- a/src/components/map/mixins/withWatchers.js
+++ b/src/components/map/mixins/withWatchers.js
@@ -35,7 +35,7 @@ const watchers = {
     this.map.setPitch(next);
   },
   light(next) {
-    this.map.setLigh(next);
+    this.map.setLight(next);
   }
 };
 


### PR DESCRIPTION
The `setLight` proxy in the watchers had a typo as `setLigh()` - this PR fixes this typo.