### PR TITLE
add cooperativeGestures option

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -295,6 +295,13 @@
 - **Description:** A `fitBounds` object to use only when fitting the initial `bounds` provided above
 - **See:** `options.fitBoundsOptions` in [Map](https://docs.mapbox.com/mapbox-gl-js/api/#map)
 
+### `cooperativeGestures`
+
+- **Type:** `Boolean`
+- **Default:** `true`
+- **Description:** If true , scroll zoom will require pressing the ctrl or ⌘ key while scrolling to zoom map
+- **See:** `options.cooperativeGestures` in [Map](https://docs.mapbox.com/mapbox-gl-js/api/#map)
+
 ## Actions
 
 Asynchronous actions exposed via `GlMap.actions`

--- a/src/components/map/options.js
+++ b/src/components/map/options.js
@@ -186,5 +186,9 @@ export default {
   crossSourceCollisions: {
     type: Boolean,
     default: true
+  },
+  cooperativeGestures: {
+    type: Boolean,
+    default: true
   }
 };


### PR DESCRIPTION
Peace be upon you guys!
I hope you're doing well.
I've added support to cooperative gestures, enabling zoom scrolling only when holding ctrl/command key.
sample usage:
```vue
<mgl-map
    id="map"
    :access-token="accessToken"
    :map-style="style"
    :cooperative-gestures="true"
    @load="onMapLoad"
/>
```
screenshot:

![image](https://user-images.githubusercontent.com/37983260/173920628-721588b8-7329-4dae-8259-2128ee2e7cd1.png)

incase someone needed this feature before this pull is merged you can use it by installing the package from this pull request directly:
`npm i soal/vue-mapbox#pull/258/head`

have a nice day.
thanks