### PR TITLE
Add feature support locale and cooperativeGestures options

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -295,6 +295,20 @@
 - **Description:** A `fitBounds` object to use only when fitting the initial `bounds` provided above
 - **See:** `options.fitBoundsOptions` in [Map](https://docs.mapbox.com/mapbox-gl-js/api/#map)
 
+### `cooperativeGestures`
+
+- **Type:** `Boolean`
+- **Default:** `true`
+- **Description:** If true , scroll zoom will require pressing the ctrl or ⌘ key while scrolling to zoom map, and touch pan will require using two fingers while panning to move the map. Touch pitch will require three fingers to activate if enabled. 
+- **See:** `options.cooperativeGestures` in [Map](https://docs.mapbox.com/mapbox-gl-js/api/#map)
+
+### `locale`
+
+- **Type:** `Object`
+- **Default:** `undefined`
+- **Description:** A patch to apply to the default localization table for UI strings such as control tooltips. The locale object maps namespaced UI string IDs to translated strings in the target language.
+- **See:** `options.locale` in [Map](https://docs.mapbox.com/mapbox-gl-js/api/#map)
+
 ## Actions
 
 Asynchronous actions exposed via `GlMap.actions`

--- a/src/components/map/options.js
+++ b/src/components/map/options.js
@@ -186,5 +186,13 @@ export default {
   crossSourceCollisions: {
     type: Boolean,
     default: true
+  },
+  cooperativeGestures: {
+    type: Boolean,
+    default: true
+  },
+  locale: {
+    type: Object,
+    default: undefined
   }
 };


### PR DESCRIPTION
Hi !

I add new options for the Vue Mapbox ! Options for supporting cooperativeGestures and locale settings

Usage example : 

```
<MglMap
    :access-token="accessToken"
    :map-style.sync="style"
    :cooperative-gestures="true"
    :locale="locale"
    @load="onMapLoad"
/>
```

If you want to use this new feature before the pull request acceptation, install Vue mapbox plugin with this command : 
`npm i soal/vue-mapbox#pull/265/head`